### PR TITLE
make initial only snapshot mode restart safe

### DIFF
--- a/src/main/java/io/debezium/connector/planetscale/VStreamCopyCompletedEventException.java
+++ b/src/main/java/io/debezium/connector/planetscale/VStreamCopyCompletedEventException.java
@@ -6,7 +6,11 @@
 package io.debezium.connector.planetscale;
 
 /**
- * Used to signal that Debezium should not continue consuming the streaming event source after encountering a COPY_COMPLETED VEvent from the VStream and when snapshot.mode=initial_only.
+ * Used to signal that Debezium should not continue consuming the streaming
+ * event source once snapshot is completed and snapshot.mode=initial_only.
  */
 public class VStreamCopyCompletedEventException extends RuntimeException {
+    public VStreamCopyCompletedEventException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/io/debezium/connector/planetscale/VitessChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/planetscale/VitessChangeRecordEmitter.java
@@ -5,34 +5,25 @@
  */
 package io.debezium.connector.planetscale;
 
-import java.util.List;
 import java.util.Objects;
 
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.planetscale.connection.ReplicationMessage;
 import io.debezium.data.Envelope;
 import io.debezium.pipeline.EventDispatcher;
-import io.debezium.relational.Column;
 import io.debezium.relational.RelationalChangeRecordEmitter;
-import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
 import io.debezium.util.Clock;
-import io.debezium.util.Strings;
 
 /**
  * Used by {@link EventDispatcher} to get the {@link SourceRecord} {@link Struct} and pass it to a
  * {@link Receiver}, which in turn enqueue the {@link SourceRecord} to {@link ChangeEventQueue}.
  */
 class VitessChangeRecordEmitter extends RelationalChangeRecordEmitter<VitessPartition> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(VitessChangeRecordEmitter.class);
-
     private final ReplicationMessage message;
     private final VitessDatabaseSchema schema;
     private final VitessConnectorConfig connectorConfig;
@@ -79,7 +70,7 @@ class VitessChangeRecordEmitter extends RelationalChangeRecordEmitter<VitessPart
                 return null;
             default:
                 // UPDATE and DELETE have old values
-                return columnValues(message.getOldTupleList(), tableId);
+                return VitessChangeRecordUtil.columnValues(connectorConfig, schema, message.getOldTupleList(), tableId);
         }
     }
 
@@ -88,7 +79,7 @@ class VitessChangeRecordEmitter extends RelationalChangeRecordEmitter<VitessPart
         switch (getOperation()) {
             case CREATE:
             case UPDATE:
-                return columnValues(message.getNewTupleList(), tableId);
+                return VitessChangeRecordUtil.columnValues(connectorConfig, schema, message.getNewTupleList(), tableId);
             default:
                 // DELETE does not have new values
                 return null;
@@ -99,45 +90,5 @@ class VitessChangeRecordEmitter extends RelationalChangeRecordEmitter<VitessPart
     protected void emitTruncateRecord(Receiver receiver, TableSchema tableSchema) throws InterruptedException {
         Struct envelope = tableSchema.getEnvelopeSchema().truncate(getOffset().getSourceInfo(), getClock().currentTimeAsInstant());
         receiver.changeRecord(getPartition(), tableSchema, Envelope.Operation.TRUNCATE, null, envelope, getOffset(), null);
-    }
-
-    private Object[] columnValues(List<ReplicationMessage.Column> columns, TableId tableId) {
-        if (columns == null || columns.isEmpty()) {
-            return null;
-        }
-        final Table table = schema.tableFor(tableId);
-        Objects.requireNonNull(table);
-
-        Object[] values = new Object[columns.size()];
-        for (ReplicationMessage.Column column : columns) {
-            final String columnName = Strings.unquoteIdentifierPart(column.getName());
-            int position = getPosition(columnName, table, values.length);
-            if (position != -1) {
-                Object value = column.getValue(connectorConfig.includeUnknownDatatypes());
-                values[position] = value;
-            }
-            else {
-                LOGGER.error("Can not find position for {} in {}", columnName, table);
-            }
-        }
-        return values;
-    }
-
-    private int getPosition(String columnName, Table table, int maxPosition) {
-        final Column tableColumn = table.columnWithName(columnName);
-        if (tableColumn == null) {
-            LOGGER.warn(
-                    "Internal schema is out-of-sync with incoming decoder events; column {} will be omitted from the change event.",
-                    columnName);
-            return -1;
-        }
-        int position = tableColumn.position() - 1;
-        if (position < 0 || position >= maxPosition) {
-            LOGGER.warn(
-                    "Internal schema is out-of-sync with incoming decoder events; column {} will be omitted from the change event.",
-                    columnName);
-            return -1;
-        }
-        return position;
     }
 }

--- a/src/main/java/io/debezium/connector/planetscale/VitessChangeRecordUtil.java
+++ b/src/main/java/io/debezium/connector/planetscale/VitessChangeRecordUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.planetscale;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.planetscale.connection.ReplicationMessage;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.util.Strings;
+
+final class VitessChangeRecordUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VitessChangeRecordUtil.class);
+
+    static Object[] columnValues(VitessConnectorConfig connectorConfig, VitessDatabaseSchema schema, List<ReplicationMessage.Column> columns, TableId tableId) {
+        if (columns == null || columns.isEmpty()) {
+            return null;
+        }
+        final Table table = schema.tableFor(tableId);
+        Objects.requireNonNull(table);
+
+        Object[] values = new Object[columns.size()];
+        for (ReplicationMessage.Column column : columns) {
+            final String columnName = Strings.unquoteIdentifierPart(column.getName());
+            int position = getPosition(columnName, table, values.length);
+            if (position != -1) {
+                Object value = column.getValue(connectorConfig.includeUnknownDatatypes());
+                values[position] = value;
+            }
+            else {
+                LOGGER.error("Can not find position for {} in {}", columnName, table);
+            }
+        }
+        return values;
+    }
+
+    static int getPosition(String columnName, Table table, int maxPosition) {
+        final Column tableColumn = table.columnWithName(columnName);
+        if (tableColumn == null) {
+            LOGGER.warn(
+                    "Internal schema is out-of-sync with incoming decoder events; column {} will be omitted from the change event.",
+                    columnName);
+            return -1;
+        }
+        int position = tableColumn.position() - 1;
+        if (position < 0 || position >= maxPosition) {
+            LOGGER.warn(
+                    "Internal schema is out-of-sync with incoming decoder events; column {} will be omitted from the change event.",
+                    columnName);
+            return -1;
+        }
+        return position;
+    }
+}

--- a/src/main/java/io/debezium/connector/planetscale/VitessOffsetContext.java
+++ b/src/main/java/io/debezium/connector/planetscale/VitessOffsetContext.java
@@ -11,8 +11,6 @@ import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.planetscale.connection.VitessReplicationConnection;
@@ -31,8 +29,7 @@ import io.debezium.util.Clock;
  * ReplicationMessage.
  */
 public class VitessOffsetContext extends CommonOffsetContext<SourceInfo> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(VitessOffsetContext.class);
-    private static final String SNAPSHOT_COMPLETED_KEY = "snapshot_completed";
+    public static final String SNAPSHOT_COMPLETED_KEY = "snapshot_completed";
 
     private boolean snapshotCompleted;
     private final Schema sourceInfoSchema;
@@ -61,7 +58,6 @@ public class VitessOffsetContext extends CommonOffsetContext<SourceInfo> {
     /** Initialize VitessOffsetContext if no previous offset exists */
     public static VitessOffsetContext initialContext(
                                                      boolean snapshot, VitessConnectorConfig connectorConfig, Clock clock) {
-        LOGGER.info("No previous offset exists. Use default VGTID.");
         final Vgtid defaultVgtid = VitessReplicationConnection.defaultVgtid(connectorConfig);
         return new VitessOffsetContext(
                 snapshot, false, connectorConfig, defaultVgtid, clock.currentTimeAsInstant(), new TransactionContext());
@@ -102,6 +98,7 @@ public class VitessOffsetContext extends CommonOffsetContext<SourceInfo> {
             if (!snapshotCompleted) {
                 result.put(SourceInfo.SNAPSHOT_KEY, true);
             }
+            result.put(SNAPSHOT_COMPLETED_KEY, snapshotCompleted);
         }
         // put OFFSET_TRANSACTION_ID
         return transactionContext.store(result);
@@ -115,6 +112,10 @@ public class VitessOffsetContext extends CommonOffsetContext<SourceInfo> {
     @Override
     public boolean isSnapshotRunning() {
         return sourceInfo.isSnapshot() && !snapshotCompleted;
+    }
+
+    public boolean isSnapshotCompleted() {
+        return snapshotCompleted;
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/planetscale/VitessSnapshotRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/planetscale/VitessSnapshotRecordEmitter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.planetscale;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.planetscale.connection.ReplicationMessage;
+import io.debezium.relational.SnapshotChangeRecordEmitter;
+import io.debezium.util.Clock;
+
+class VitessSnapshotRecordEmitter extends SnapshotChangeRecordEmitter<VitessPartition> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VitessSnapshotRecordEmitter.class);
+
+    VitessSnapshotRecordEmitter(
+                                VitessPartition partition,
+                                VitessOffsetContext offsetContext,
+                                Clock clock,
+                                VitessConnectorConfig connectorConfig,
+                                VitessDatabaseSchema schema,
+                                ReplicationMessage message) {
+        super(
+                partition,
+                offsetContext,
+                VitessChangeRecordUtil.columnValues(
+                        connectorConfig, schema, message.getNewTupleList(), VitessDatabaseSchema.parse(message.getTable())),
+                clock,
+                connectorConfig);
+    }
+}

--- a/src/main/java/io/debezium/connector/planetscale/VitessStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/planetscale/VitessStreamingChangeEventSource.java
@@ -18,6 +18,7 @@ import io.debezium.connector.planetscale.connection.ReplicationMessage;
 import io.debezium.connector.planetscale.connection.ReplicationMessageProcessor;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.EventDispatcher.SnapshotReceiver;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -57,7 +58,6 @@ public class VitessStreamingChangeEventSource
         this.connectorConfig = connectorConfig;
         this.replicationConnection = replicationConnection;
         this.pauseNoMessage = DelayStrategy.constant(connectorConfig.getPollInterval());
-
         LOGGER.info("VitessStreamingChangeEventSource is created");
     }
 
@@ -78,16 +78,18 @@ public class VitessStreamingChangeEventSource
         }
 
         try {
-            AtomicReference<Throwable> error = new AtomicReference<>();
-            replicationConnection.startStreaming(
-                    offsetContext, newReplicationMessageProcessor(partition, offsetContext), error);
+            if (connectorConfig.getSnapshotMode() != SnapshotMode.INITIAL_ONLY || !offsetContext.isSnapshotCompleted()) {
+                AtomicReference<Throwable> error = new AtomicReference<>();
+                replicationConnection.startStreaming(
+                        offsetContext, newReplicationMessageProcessor(partition, offsetContext), error);
 
-            while (context.isRunning() && error.get() == null) {
-                pauseNoMessage.sleepWhen(true);
-            }
-            if (error.get() != null) {
-                LOGGER.error("Error during streaming", error.get());
-                throw error.get();
+                while (context.isRunning() && error.get() == null) {
+                    pauseNoMessage.sleepWhen(true);
+                }
+                if (error.get() != null) {
+                    LOGGER.error("Error during streaming", error.get());
+                    throw error.get();
+                }
             }
         }
         catch (Throwable e) {
@@ -112,6 +114,7 @@ public class VitessStreamingChangeEventSource
 
     private ReplicationMessageProcessor newReplicationMessageProcessor(VitessPartition partition,
                                                                        VitessOffsetContext offsetContext) {
+        SnapshotReceiver<VitessPartition> receiver = dispatcher.getSnapshotChangeEventReceiver();
         return (message, newVgtid, isLastRowOfTransaction) -> {
             if (message.isTransactionalMessage()) {
                 // Tx BEGIN/END event
@@ -154,6 +157,14 @@ public class VitessStreamingChangeEventSource
                         new VitessDDLEmitter(
                                 partition, offsetContext, connectorConfig.ddlFilter(), schema, message));
             }
+            else if (message.getOperation() == ReplicationMessage.Operation.COPY_COMPLETED) {
+                LOGGER.debug("processing COPY_COMPLETED operation by completing snapshot");
+                offsetContext.rotateVgtid(newVgtid, message.getCommitTime());
+                offsetContext.setShard("-");
+                offsetContext.preSnapshotCompletion();
+                receiver.completeSnapshot();
+                offsetContext.postSnapshotCompletion();
+            }
             else {
                 // DML event
                 TableId tableId = VitessDatabaseSchema.parse(message.getTable());
@@ -167,11 +178,20 @@ public class VitessStreamingChangeEventSource
                     offsetContext.resetVgtid(newVgtid, message.getCommitTime());
                 }
 
-                dispatcher.dispatchDataChangeEvent(
-                        partition,
-                        tableId,
-                        new VitessChangeRecordEmitter(
-                                partition, offsetContext, clock, connectorConfig, schema, message));
+                if (offsetContext.isSnapshotRunning()) {
+                    dispatcher.dispatchSnapshotEvent(partition,
+                            tableId,
+                            new VitessSnapshotRecordEmitter(
+                                    partition, offsetContext, clock, connectorConfig, schema, message),
+                            receiver);
+                }
+                else {
+                    dispatcher.dispatchDataChangeEvent(
+                            partition,
+                            tableId,
+                            new VitessChangeRecordEmitter(
+                                    partition, offsetContext, clock, connectorConfig, schema, message));
+                }
             }
         };
     }

--- a/src/main/java/io/debezium/connector/planetscale/connection/CopyCompletedMessage.java
+++ b/src/main/java/io/debezium/connector/planetscale/connection/CopyCompletedMessage.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.planetscale.connection;
+
+import java.time.Instant;
+import java.util.List;
+
+import io.debezium.schema.SchemaChangeEvent;
+
+/** Whether this message represents an COPY_COMPLETED event.*/
+public class CopyCompletedMessage implements ReplicationMessage {
+
+    private final Instant commitTime;
+    private final Operation operation;
+
+    public CopyCompletedMessage(Instant commitTime) {
+        this.commitTime = commitTime;
+        this.operation = Operation.COPY_COMPLETED;
+    }
+
+    @Override
+    public String getDDL() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SchemaChangeEvent.SchemaChangeEventType getSchemaChangeType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Operation getOperation() {
+        return operation;
+    }
+
+    @Override
+    public Instant getCommitTime() {
+        return commitTime;
+    }
+
+    @Override
+    public String getTransactionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getTable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getShard() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Column> getOldTupleList() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Column> getNewTupleList() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isTransactionalMessage() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "OtherMessage{"
+                + "commitTime="
+                + commitTime
+                + ", operation="
+                + operation
+                + '}';
+    }
+}

--- a/src/main/java/io/debezium/connector/planetscale/connection/ReplicationMessage.java
+++ b/src/main/java/io/debezium/connector/planetscale/connection/ReplicationMessage.java
@@ -30,7 +30,8 @@ public interface ReplicationMessage {
         COMMIT,
         DDL,
         TRUNCATE,
-        OTHER
+        OTHER,
+        COPY_COMPLETED
     }
 
     /** A representation of column value delivered as a part of replication message */

--- a/src/main/java/io/debezium/connector/planetscale/connection/VStreamOutputMessageDecoder.java
+++ b/src/main/java/io/debezium/connector/planetscale/connection/VStreamOutputMessageDecoder.java
@@ -80,6 +80,9 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
             case COMMIT:
                 handleCommitMessage(vEvent, processor, newVgtid);
                 break;
+            case COPY_COMPLETED:
+                handleCopyCompleted(vEvent, processor, newVgtid);
+                break;
             case ROW:
                 decodeRows(vEvent, processor, newVgtid, isLastRowEventOfTransaction, isSnapshotRecord, snapshotStartedAt);
                 break;
@@ -206,6 +209,13 @@ public class VStreamOutputMessageDecoder implements MessageDecoder {
         LOGGER.trace("Commit timestamp of commit transaction: {}", commitTimestamp);
         processor.process(
                 new TransactionalMessage(Operation.COMMIT, transactionId, commitTimestamp), newVgtid, false);
+    }
+
+    private void handleCopyCompleted(
+                                     Binlogdata.VEvent vEvent, ReplicationMessageProcessor processor, Vgtid newVgtid)
+            throws InterruptedException {
+        this.commitTimestamp = Instant.ofEpochSecond(vEvent.getTimestamp());
+        processor.process(new CopyCompletedMessage(commitTimestamp), newVgtid, false);
     }
 
     private void decodeRows(

--- a/src/main/java/io/debezium/connector/planetscale/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/planetscale/connection/VitessReplicationConnection.java
@@ -116,13 +116,7 @@ public class VitessReplicationConnection implements ReplicationConnection {
             stub = MetadataUtils.attachHeaders(stub, metadata);
         }
 
-        final Instant startedSnapshotAt;
-        if (config.getSnapshotMode() == SnapshotMode.INITIAL_ONLY) {
-            startedSnapshotAt = VitessConnector.getCurrentTimestamp(config);
-        }
-        else {
-            startedSnapshotAt = null;
-        }
+        final Instant startedSnapshotAt = VitessConnector.getCurrentTimestamp(config);
 
         StreamObserver<Vtgate.VStreamResponse> responseObserver = new ClientResponseObserver<Vtgate.VStreamRequest, Vtgate.VStreamResponse>() {
             private ClientCallStreamObserver<VStreamRequest> requestStream;

--- a/src/main/java/io/debezium/connector/planetscale/connection/VitessReplicationConnection.java
+++ b/src/main/java/io/debezium/connector/planetscale/connection/VitessReplicationConnection.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
-import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.planetscale.VStreamCopyCompletedEventException;
 import io.debezium.connector.planetscale.Vgtid;
 import io.debezium.connector.planetscale.VitessConnector;
@@ -209,19 +208,14 @@ public class VitessReplicationConnection implements ReplicationConnection {
                             commitEventSeen = true;
                             break;
                         case COPY_COMPLETED:
-                            // After all shards are copied, Vitess will send a final COPY_COMPLETED event.
-                            // See:
-                            // https://github.com/vitessio/vitess/blob/v19.0.0/go/vt/vtgate/vstream_manager.go#L791-L808
                             if (event.getKeyspace() == "" && event.getShard() == "") {
                                 LOGGER.info("Received COPY_COMPLETED event for all keyspaces and shards");
-                                offsetContext.markSnapshotRecord(SnapshotRecord.FALSE);
                                 copyCompletedEventSeen = true;
                             }
                             else {
                                 LOGGER.info("Received COPY_COMPLETED event for keyspace {} and shard {}",
                                         event.getKeyspace(), event.getShard());
                             }
-                            continue;
                         case DDL:
                         case OTHER:
                             // If receiving DDL and OTHER, process them immediately to rotate vgtid in
@@ -234,6 +228,9 @@ public class VitessReplicationConnection implements ReplicationConnection {
                             break;
                     }
                     bufferedEvents.add(event);
+                    if (config.getSnapshotMode() == SnapshotMode.INITIAL_ONLY && copyCompletedEventSeen) {
+                        break;
+                    }
                 }
 
                 numResponses++;
@@ -285,11 +282,9 @@ public class VitessReplicationConnection implements ReplicationConnection {
                 }
 
                 if (copyCompletedEventSeen) {
-                    LOGGER.info("Received COPY_COMPLETED event for all keyspaces and shards");
                     if (config.getSnapshotMode() == SnapshotMode.INITIAL_ONLY) {
-                        LOGGER.info("Cancel the copy operation after receiving COPY_COMPLETED event");
-                        requestStream.cancel("Cancel the copy operation after receiving COPY_COMPLETED event",
-                                new VStreamCopyCompletedEventException());
+                        final String message = "COPY_COMPLETED event encountered during INITIAL_ONLY snapshot";
+                        requestStream.cancel(message, new VStreamCopyCompletedEventException(message));
                     }
                 }
             }

--- a/src/test/java/io/debezium/connector/planetscale/VitessConnectorIT.java
+++ b/src/test/java/io/debezium/connector/planetscale/VitessConnectorIT.java
@@ -890,7 +890,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         int expectedRecordsCount = 1;
         consumer = testConsumer(expectedRecordsCount);
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
-        SourceRecord record = assertRecordInserted(topicNameFromInsertStmt(INSERT_NUMERIC_TYPES_STMT), TestHelper.PK_FIELD);
+        SourceRecord record = assertRecordRead(topicNameFromInsertStmt(INSERT_NUMERIC_TYPES_STMT), TestHelper.PK_FIELD);
         assertSourceInfo(record, TEST_SERVER, TEST_UNSHARDED_KEYSPACE, "numeric_table");
         assertRecordSchemaAndValues(schemasAndValuesForNumericTypes(), record, Envelope.FieldName.AFTER);
 
@@ -928,11 +928,12 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         int expectedRecordsCount = 1;
         consumer = testConsumer(expectedRecordsCount);
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
-        SourceRecord record = assertRecordInserted(topicNameFromInsertStmt(INSERT_NUMERIC_TYPES_STMT, TEST_SHARDED_KEYSPACE), TestHelper.PK_FIELD);
+        SourceRecord record = assertRecordRead(topicNameFromInsertStmt(INSERT_NUMERIC_TYPES_STMT, TEST_SHARDED_KEYSPACE), TestHelper.PK_FIELD);
         assertSourceInfo(record, TEST_SERVER, TEST_SHARDED_KEYSPACE, "numeric_table");
         assertRecordSchemaAndValues(schemasAndValuesForNumericTypes(), record, Envelope.FieldName.AFTER);
 
-        waitForCopyCompleted();
+        Boolean snapshotCompleted = (Boolean) record.sourceOffset().get(VitessOffsetContext.SNAPSHOT_COMPLETED_KEY);
+        assertThat(snapshotCompleted).isTrue();
 
         // We should receive additional record from numeric_table
         consumer.expects(expectedRecordsCount);
@@ -955,12 +956,13 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         int expectedRecordsCount = 1;
         consumer = testConsumer(expectedRecordsCount);
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
-        SourceRecord record = assertRecordInserted(topicNameFromInsertStmt(INSERT_NUMERIC_TYPES_STMT), TestHelper.PK_FIELD);
+        SourceRecord record = assertRecordRead(topicNameFromInsertStmt(INSERT_NUMERIC_TYPES_STMT), TestHelper.PK_FIELD);
         assertSourceInfo(record, TEST_SERVER, TEST_UNSHARDED_KEYSPACE, "numeric_table");
         assertRecordSchemaAndValues(schemasAndValuesForNumericTypes(), record, Envelope.FieldName.AFTER);
 
         // Restart the connector.
-        waitForCopyCompleted();
+        Boolean snapshotCompleted = (Boolean) record.sourceOffset().get(VitessOffsetContext.SNAPSHOT_COMPLETED_KEY);
+        assertThat(snapshotCompleted).isTrue();
         stopConnector();
         startConnector(Function.identity(), false, false, 1, -1, -1, null, null, null);
 
@@ -980,7 +982,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         int expectedRecordsCount = 1;
         consumer = testConsumer(expectedRecordsCount);
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
-        SourceRecord record = assertRecordInserted(topicNameFromInsertStmt(INSERT_NUMERIC_TYPES_STMT), TestHelper.PK_FIELD);
+        SourceRecord record = assertRecordRead(topicNameFromInsertStmt(INSERT_NUMERIC_TYPES_STMT), TestHelper.PK_FIELD);
         assertSourceInfo(record, TEST_SERVER, TEST_UNSHARDED_KEYSPACE, "numeric_table");
         assertRecordSchemaAndValues(schemasAndValuesForNumericTypes(), record, Envelope.FieldName.AFTER);
 
@@ -1028,7 +1030,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         consumer = testConsumer(expectedSnapshotRecordsCount, tableInclude);
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
-        assertRecordInserted(TEST_UNSHARDED_KEYSPACE + ".numeric_table", TestHelper.PK_FIELD);
+        assertRecordRead(TEST_UNSHARDED_KEYSPACE + ".numeric_table", TestHelper.PK_FIELD);
 
         // Add more rows.
         TestHelper.execute(insertRowsStatement);
@@ -1134,7 +1136,7 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         // The inserts must happen only after VStream is started with some buffer time.
         Awaitility.await().atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
                 .pollInterval(Duration.ofSeconds(1))
-                .until(() -> logInterceptor.containsMessage("Cancel the copy operation after receiving COPY_COMPLETED event"));
+                .until(() -> logInterceptor.containsMessage("COPY_COMPLETED event encountered during INITIAL_ONLY snapshot"));
     }
 
     private void waitForVStreamStarted(final LogInterceptor logInterceptor) {
@@ -1266,6 +1268,12 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
         return assertRecordInserted(insertedRecord, expectedTopicName, pkField);
     }
 
+    private SourceRecord assertRecordRead(String expectedTopicName, String pkField) {
+        assertFalse("records not generated", consumer.isEmpty());
+        SourceRecord readRecord = consumer.remove();
+        return assertRecordRead(readRecord, expectedTopicName, pkField);
+    }
+
     private SourceRecord assertRecordUpdated() {
         assertFalse("records not generated", consumer.isEmpty());
         SourceRecord updatedRecord = consumer.remove();
@@ -1287,6 +1295,17 @@ public class VitessConnectorIT extends AbstractVitessConnectorTest {
             VerifyRecord.isValidInsert(insertedRecord);
         }
         return insertedRecord;
+    }
+
+    private SourceRecord assertRecordRead(SourceRecord readRecord, String expectedTopicName, String pkField) {
+        assertEquals(topicName(expectedTopicName), readRecord.topic());
+        if (pkField != null) {
+            VitessVerifyRecord.isValidRead(readRecord, pkField);
+        }
+        else {
+            VerifyRecord.isValidRead(readRecord);
+        }
+        return readRecord;
     }
 
     private SourceRecord assertRecordUpdated(SourceRecord updatedRecord) {

--- a/src/test/java/io/debezium/connector/planetscale/VitessReplicationConnectionIT.java
+++ b/src/test/java/io/debezium/connector/planetscale/VitessReplicationConnectionIT.java
@@ -60,7 +60,7 @@ public class VitessReplicationConnectionIT {
         final VitessConnectorConfig conf = new VitessConnectorConfig(
                 TestHelper.defaultConfig(false, false, 1, -1, -1,
                         null, VitessConnectorConfig.SnapshotMode.NEVER, TestHelper.TEST_SHARD,
-                        "1", "skip").build());
+                        null, "skip").build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
                 conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
 
@@ -88,6 +88,7 @@ public class VitessReplicationConnectionIT {
                         started.set(true);
                     }
                     consumedMessages.add(new MessageAndVgtid(message, vgtid));
+                    throw new InterruptedException("intentional test failure");
                 },
                 error);
         // Since we are using the "current" as the starting position, there is a race here
@@ -98,6 +99,7 @@ public class VitessReplicationConnectionIT {
                 .atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
                 .until(() -> error.get() != null);
         assertThat(error.get()).isNotNull();
+        assertThat(error.get()).hasMessage("intentional test failure");
     }
 
     @Test
@@ -107,7 +109,7 @@ public class VitessReplicationConnectionIT {
         final VitessConnectorConfig conf = new VitessConnectorConfig(
                 TestHelper.defaultConfig(false, false, 1, -1, -1,
                         null, VitessConnectorConfig.SnapshotMode.NEVER, TestHelper.TEST_SHARD,
-                        "1", "warn").build());
+                        null, "warn").build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
                 conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
 
@@ -135,6 +137,7 @@ public class VitessReplicationConnectionIT {
                         started.set(true);
                     }
                     consumedMessages.add(new MessageAndVgtid(message, vgtid));
+                    throw new InterruptedException("intentional test failure");
                 },
                 error);
         // Since we are using the "current" as the starting position, there is a race here
@@ -145,6 +148,7 @@ public class VitessReplicationConnectionIT {
                 .atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
                 .until(() -> error.get() != null);
         assertThat(error.get()).isNotNull();
+        assertThat(error.get()).hasMessage("intentional test failure");
     }
 
     @Test
@@ -153,7 +157,7 @@ public class VitessReplicationConnectionIT {
         final VitessConnectorConfig conf = new VitessConnectorConfig(
                 TestHelper.defaultConfig(false, false, 1, -1, -1,
                         null, VitessConnectorConfig.SnapshotMode.NEVER, TestHelper.TEST_SHARD,
-                        "1", "fail").build());
+                        null, "fail").build());
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
                 conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
 
@@ -181,6 +185,7 @@ public class VitessReplicationConnectionIT {
                         started.set(true);
                     }
                     consumedMessages.add(new MessageAndVgtid(message, vgtid));
+                    throw new InterruptedException("intentional test failure");
                 },
                 error);
         // Since we are using the "current" as the starting position, there is a race here
@@ -191,6 +196,7 @@ public class VitessReplicationConnectionIT {
                 .atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
                 .until(() -> error.get() != null);
         assertThat(error.get()).isNotNull();
+        assertThat(error.get()).hasMessage("intentional test failure");
     }
 
     @Test
@@ -199,7 +205,7 @@ public class VitessReplicationConnectionIT {
         final VitessConnectorConfig conf = new VitessConnectorConfig(
                 TestHelper.defaultConfig(false, false, 1, -1, -1,
                         null, VitessConnectorConfig.SnapshotMode.NEVER, TestHelper.TEST_SHARD,
-                        "1", null).build());
+                        null, null).build());
         conf.getEventProcessingFailureHandlingMode();
         final VitessDatabaseSchema vitessDatabaseSchema = new VitessDatabaseSchema(
                 conf, SchemaNameAdjuster.create(), (TopicNamingStrategy) DefaultTopicNamingStrategy.create(conf));
@@ -228,6 +234,7 @@ public class VitessReplicationConnectionIT {
                         started.set(true);
                     }
                     consumedMessages.add(new MessageAndVgtid(message, vgtid));
+                    throw new InterruptedException("intentional test failure");
                 },
                 error);
         // Since we are using the "current" as the starting position, there is a race here
@@ -238,6 +245,7 @@ public class VitessReplicationConnectionIT {
                 .atMost(Duration.ofSeconds(TestHelper.waitTimeForRecords()))
                 .until(() -> error.get() != null);
         assertThat(error.get()).isNotNull();
+        assertThat(error.get()).hasMessage("intentional test failure");
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/planetscale/VitessVerifyRecord.java
+++ b/src/test/java/io/debezium/connector/planetscale/VitessVerifyRecord.java
@@ -29,6 +29,17 @@ public class VitessVerifyRecord extends VerifyRecord {
     }
 
     /**
+     * Verify that the given {@link SourceRecord} is a READ record, and that the key exists.
+     *
+     * @param record the source record; may not be null
+     * @param pkField the single field defining the primary key of the struct; may not be null
+     */
+    public static void isValidRead(SourceRecord record, String pkField) {
+        hasValidKey(record, pkField);
+        isValidRead(record);
+    }
+
+    /**
      * Verify that the given {@link SourceRecord} has a valid non-null integer key.
      *
      * @param record the source record; may not be null


### PR DESCRIPTION
If a connector configured with `initial_only` is restarted after it receives a `COPY_COMPLETED` event, it will continue process VStream events.

Address this by:

* Utilizing existing utilities for generating taking snapshots `dispatchSnapshotEvent` and `completeSnapshot`.
* Record `snapshot_completed` key in the offset.
* Don't resume VStream when starting connector and we see `snapshot_completed=true` in offset.

Note that `initial_only` is not restart safe if it is interrupted mid snapshot. To fix that we need https://github.com/debezium/debezium-connector-vitess/commit/78d06a1986f908a96fab2418e639162907e42e75 which is available in v2.4.1 of the connector.