### PR TITLE
fix: handle MySQL zero-date values in ReplicationMessageColumnValueResolver (2.4 backport)

### DIFF
--- a/src/main/java/io/debezium/connector/planetscale/VitessType.java
+++ b/src/main/java/io/debezium/connector/planetscale/VitessType.java
@@ -42,6 +42,10 @@ public class VitessType {
     }
 
     public Integer getEnumOrdinal(String value) {
+        // MySQL enum ordinal 0 = empty/invalid value (stored as '')
+        if (value == null || value.isEmpty()) {
+            return 0;
+        }
         int index = enumValues.indexOf(value);
         if (index == -1) {
             return Integer.valueOf(value);

--- a/src/main/java/io/debezium/connector/planetscale/VitessType.java
+++ b/src/main/java/io/debezium/connector/planetscale/VitessType.java
@@ -54,13 +54,26 @@ public class VitessType {
     }
 
     public Long getSetNumeral(String value) {
+        // Empty SET value → 0 (no members selected)
+        if (value == null || value.isEmpty()) {
+            return 0L;
+        }
         String[] members = value.split(",");
         Long result = 0L;
         for (String member : members) {
+            if (member.isEmpty()) {
+                continue;
+            }
             long index = enumValues.indexOf(member);
             if (index == -1) {
-                index = Long.valueOf(member);
-                return index;
+                // Unknown member name — try parsing as numeric (legacy behavior)
+                try {
+                    return Long.valueOf(member);
+                }
+                catch (NumberFormatException e) {
+                    // Malformed SET value; skip this member
+                    continue;
+                }
             }
             else {
                 Double power = Math.pow(2, index);

--- a/src/main/java/io/debezium/connector/planetscale/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/planetscale/connection/ReplicationMessageColumnValueResolver.java
@@ -10,10 +10,16 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.debezium.connector.planetscale.VitessType;
 
 /** Resolve raw column value to Java value */
 public class ReplicationMessageColumnValueResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReplicationMessageColumnValueResolver.class);
+    private static final java.util.regex.Pattern ZERO_DATE_PATTERN = java.util.regex.Pattern.compile("^\\d{4}-00-00.*$");
 
     public static Object resolveValue(
                                       VitessType vitessType, ReplicationMessage.ColumnValue<byte[]> value, boolean includeUnknownDatatypes) {
@@ -38,11 +44,11 @@ public class ReplicationMessageColumnValueResolver {
             case Types.BINARY:
                 return value.asBytes();
             case Types.DATE:
-                return Date.valueOf(value.asString());
+                return stringToDate(value.asString());
             case Types.TIME:
                 return Time.valueOf(value.asString());
             case Types.TIMESTAMP:
-                return Timestamp.valueOf(value.asString());
+                return stringToTimestamp(value.asString());
             case Types.TIMESTAMP_WITH_TIMEZONE:
                 return value.asString();
             case Types.VARCHAR:
@@ -56,5 +62,21 @@ public class ReplicationMessageColumnValueResolver {
         }
 
         return value.asDefault(vitessType, includeUnknownDatatypes);
+    }
+
+    private static Timestamp stringToTimestamp(String value) {
+        if (ZERO_DATE_PATTERN.matcher(value).matches()) {
+            LOGGER.warn("Invalid timestamp '{}' converted to null", value);
+            return null;
+        }
+        return Timestamp.valueOf(value);
+    }
+
+    private static Date stringToDate(String value) {
+        if (ZERO_DATE_PATTERN.matcher(value).matches()) {
+            LOGGER.warn("Invalid date '{}' converted to null", value);
+            return null;
+        }
+        return Date.valueOf(value);
     }
 }

--- a/src/main/java/io/debezium/connector/planetscale/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/planetscale/connection/ReplicationMessageColumnValueResolver.java
@@ -47,7 +47,7 @@ public class ReplicationMessageColumnValueResolver {
             case Types.DATE:
                 return stringToDate(value.asString());
             case Types.TIME:
-                return Time.valueOf(value.asString());
+                return stringToTime(value.asString());
             case Types.TIMESTAMP:
                 return stringToTimestamp(value.asString());
             case Types.TIMESTAMP_WITH_TIMEZONE:
@@ -70,7 +70,23 @@ public class ReplicationMessageColumnValueResolver {
             LOGGER.warn("Invalid timestamp '{}' converted to null", value);
             return null;
         }
-        return Timestamp.valueOf(value);
+        try {
+            return Timestamp.valueOf(value);
+        }
+        catch (IllegalArgumentException e) {
+            LOGGER.warn("Unparseable timestamp '{}' converted to null", value);
+            return null;
+        }
+    }
+
+    private static Time stringToTime(String value) {
+        try {
+            return Time.valueOf(value);
+        }
+        catch (IllegalArgumentException e) {
+            LOGGER.warn("Unparseable time '{}' converted to null", value);
+            return null;
+        }
     }
 
     private static Date stringToDate(String value) {
@@ -78,6 +94,12 @@ public class ReplicationMessageColumnValueResolver {
             LOGGER.warn("Invalid date '{}' converted to null", value);
             return null;
         }
-        return Date.valueOf(value);
+        try {
+            return Date.valueOf(value);
+        }
+        catch (IllegalArgumentException e) {
+            LOGGER.warn("Unparseable date '{}' converted to null", value);
+            return null;
+        }
     }
 }

--- a/src/main/java/io/debezium/connector/planetscale/connection/ReplicationMessageColumnValueResolver.java
+++ b/src/main/java/io/debezium/connector/planetscale/connection/ReplicationMessageColumnValueResolver.java
@@ -9,6 +9,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +20,7 @@ import io.debezium.connector.planetscale.VitessType;
 public class ReplicationMessageColumnValueResolver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReplicationMessageColumnValueResolver.class);
-    private static final java.util.regex.Pattern ZERO_DATE_PATTERN = java.util.regex.Pattern.compile("^\\d{4}-00-00.*$");
+    private static final Pattern ZERO_DATE_PATTERN = Pattern.compile("^\\d{4}-00-00.*$");
 
     public static Object resolveValue(
                                       VitessType vitessType, ReplicationMessage.ColumnValue<byte[]> value, boolean includeUnknownDatatypes) {

--- a/src/test/java/io/debezium/connector/planetscale/VitessTypeTest.java
+++ b/src/test/java/io/debezium/connector/planetscale/VitessTypeTest.java
@@ -109,6 +109,33 @@ public class VitessTypeTest {
                 .isEqualTo(new VitessType(Query.Type.SET.name(), Types.BIGINT, Arrays.asList("e',','u", "us", "asia")));
     }
 
+    @Test
+    public void shouldHandleEmptySetValue() {
+        // Empty SET value should return 0 (no members selected), not throw NumberFormatException.
+        // This caused CDC to stop entirely when PlanetScale sent empty SET values.
+        Query.Field setField = Query.Field.newBuilder()
+                .setType(Query.Type.SET)
+                .setColumnType("set('a','b','c')")
+                .build();
+        VitessType vt = VitessType.resolve(setField);
+        assertThat(vt.getSetNumeral("")).isEqualTo(0L);
+        assertThat(vt.getSetNumeral(null)).isEqualTo(0L);
+    }
+
+    @Test
+    public void shouldComputeSetNumeralBitmask() {
+        Query.Field setField = Query.Field.newBuilder()
+                .setType(Query.Type.SET)
+                .setColumnType("set('a','b','c')")
+                .build();
+        VitessType vt = VitessType.resolve(setField);
+        assertThat(vt.getSetNumeral("a")).isEqualTo(1L); // bit 0
+        assertThat(vt.getSetNumeral("b")).isEqualTo(2L); // bit 1
+        assertThat(vt.getSetNumeral("c")).isEqualTo(4L); // bit 2
+        assertThat(vt.getSetNumeral("a,b")).isEqualTo(3L); // bits 0+1
+        assertThat(vt.getSetNumeral("a,b,c")).isEqualTo(7L); // bits 0+1+2
+    }
+
     private Query.Field asField(Query.Type type) {
         return Query.Field.newBuilder().setType(type).build();
     }

--- a/src/test/java/io/debezium/connector/planetscale/connection/ReplicationMessageColumnValueResolverTest.java
+++ b/src/test/java/io/debezium/connector/planetscale/connection/ReplicationMessageColumnValueResolverTest.java
@@ -8,6 +8,7 @@ package io.debezium.connector.planetscale.connection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.sql.Date;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 
@@ -167,6 +168,51 @@ public class ReplicationMessageColumnValueResolverTest {
         Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
                 new VitessType(AnonymousValue.getString(), Types.TIMESTAMP),
                 new VitessColumnValue("2024-00-00 00:00:00".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isNull();
+    }
+
+    @Test
+    public void shouldResolveMalformedDateToNull() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.DATE),
+                new VitessColumnValue("not-a-date".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isNull();
+    }
+
+    @Test
+    public void shouldResolveEmptyDateToNull() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.DATE),
+                new VitessColumnValue("".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isNull();
+    }
+
+    @Test
+    public void shouldResolveMalformedTimestampToNull() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.TIMESTAMP),
+                new VitessColumnValue("not-a-timestamp".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isNull();
+    }
+
+    @Test
+    public void shouldResolveTimeToTime() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.TIME),
+                new VitessColumnValue("12:30:45".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isEqualTo(Time.valueOf("12:30:45"));
+    }
+
+    @Test
+    public void shouldResolveMalformedTimeToNull() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.TIME),
+                new VitessColumnValue("not-a-time".getBytes()),
                 false);
         assertThat(resolvedJavaValue).isNull();
     }

--- a/src/test/java/io/debezium/connector/planetscale/connection/ReplicationMessageColumnValueResolverTest.java
+++ b/src/test/java/io/debezium/connector/planetscale/connection/ReplicationMessageColumnValueResolverTest.java
@@ -134,4 +134,40 @@ public class ReplicationMessageColumnValueResolverTest {
                 false);
         assertThat(resolvedJavaValue).isEqualTo("1999-12-31 23:59:59");
     }
+
+    @Test
+    public void shouldResolveZeroDateToNull() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.DATE),
+                new VitessColumnValue("0000-00-00".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isNull();
+    }
+
+    @Test
+    public void shouldResolveZeroTimestampToNull() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.TIMESTAMP),
+                new VitessColumnValue("0000-00-00 00:00:00".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isNull();
+    }
+
+    @Test
+    public void shouldResolveNonZeroYearZeroDateToNull() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.DATE),
+                new VitessColumnValue("2024-00-00".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isNull();
+    }
+
+    @Test
+    public void shouldResolveNonZeroYearZeroTimestampToNull() {
+        Object resolvedJavaValue = ReplicationMessageColumnValueResolver.resolveValue(
+                new VitessType(AnonymousValue.getString(), Types.TIMESTAMP),
+                new VitessColumnValue("2024-00-00 00:00:00".getBytes()),
+                false);
+        assertThat(resolvedJavaValue).isNull();
+    }
 }


### PR DESCRIPTION
## Problem

MySQL allows invalid date/timestamp sentinel values (`0000-00-00`, `0000-00-00 00:00:00`) which appear in the binary log and are emitted by VStream CDC events — particularly in UPDATE "before" images where the original row was inserted before `sql_mode=NO_ZERO_DATE` was enforced.

`ReplicationMessageColumnValueResolver.resolveValue()` passes these raw strings to `java.sql.Timestamp.valueOf()` and `java.sql.Date.valueOf()`, which throw `IllegalArgumentException`:

```
java.lang.IllegalArgumentException: Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]
    at java.sql.Timestamp.valueOf(Timestamp.java:249)
    at io.debezium.connector.planetscale.connection.ReplicationMessageColumnValueResolver.resolveValue(ReplicationMessageColumnValueResolver.java:45)
```

This causes Debezium Server to enter an **infinite crash-reconnect loop** — VStream CANCELLED → reconnect → hits the same bad event → blocks ALL CDC processing indefinitely.

## Fix

Add `stringToTimestamp()` and `stringToDate()` helper methods that detect zero-date patterns (`^\d{4}-00-00.*`) and return `null` with a warning log instead of crashing. This matches the approach already present in `VitessValueConverter.stringToTimestamp()` on the `3.2-planetscale` branch.

## Why backport to 2.4?

The fix for this already exists in the `3.2-planetscale` branch, but:

1. **No published release exists for 3.2.** The only published release is [`v2.4.0.Final.PS20241031.1`](https://github.com/planetscale/debezium-connector-planetscale/releases/tag/v2.4.0.Final.PS20241031.1), which is the 2.4 connector.

2. **Debezium Server 2.4.x cannot use a 3.2 connector.** The connector major version must match the Debezium platform version. Users on Debezium Server 2.4.1 (the current stable release referenced in the README) have no way to get this fix without upgrading their entire Debezium infrastructure.

3. **The fix is minimal and safe.** It's a 3-line behavioral change (regex check + null return) isolated to `ReplicationMessageColumnValueResolver` — no API changes, no new dependencies.

4. **The current workaround is lossy.** Setting `event.processing.failure.handling.mode=warn` skips entire CDC events that contain unparseable values, losing legitimate data changes. This fix preserves the event while correctly representing the invalid date as `null`.

## Testing

Verified in production with Debezium Server 2.4.1 streaming 250 tables from PlanetScale. The zero-date values appear in tables with legacy data predating strict SQL mode enforcement.