### PR TITLE
ci: use open source path filter

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,7 +45,7 @@ jobs:
           java-version: ${{ vars.JAVA_TOOLCHAIN_VERSION || '21' }}
           distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'zulu' }}
       - name: "Setup: Elide"
-        uses: elide-dev/setup-elide@d91d5859c0722417ea1ac4c682382ac8a6622b80 # main
+        uses: elide-dev/setup-elide@d2f742321bf672300c0935839b6f5c6e562a965b # v4.1.0
       - name: "Run: Claude Code"
         id: claude
         uses: anthropics/claude-code-action@6337623ebba10cf8c8214b507993f8062fd4ccfb # beta

--- a/.github/workflows/job.build.yml
+++ b/.github/workflows/job.build.yml
@@ -121,7 +121,7 @@ jobs:
           java-version: ${{ vars.JAVA_TOOLCHAIN_VERSION || '24' }}
           distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'graalvm' }}
       - name: "Setup: Elide"
-        uses: elide-dev/setup-elide@d91d5859c0722417ea1ac4c682382ac8a6622b80 # main
+        uses: elide-dev/setup-elide@d2f742321bf672300c0935839b6f5c6e562a965b # v4.1.0
       - name: "Setup: Gradle"
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v4
         with:

--- a/.github/workflows/job.review.yml
+++ b/.github/workflows/job.review.yml
@@ -69,7 +69,7 @@ jobs:
           java-version: ${{ vars.JAVA_TOOLCHAIN_VERSION || '21' }}
           distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'zulu' }}
       - name: "Setup: Elide"
-        uses: elide-dev/setup-elide@d91d5859c0722417ea1ac4c682382ac8a6622b80 # main
+        uses: elide-dev/setup-elide@d2f742321bf672300c0935839b6f5c6e562a965b # v4.1.0
       - name: "Setup: Gradle"
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v4
         with:

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -53,7 +53,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: "Triage: PR Changes"
         id: filter
-        uses: step-security/paths-filter@6eee183b0d2fd101d3f8ee2935c127bca14c5625 # v3.0.5
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: .github/triage.yml
 

--- a/.idea/debezium-connector-planetscale-private.iml
+++ b/.idea/debezium-connector-planetscale-private.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="Go" enabled="true" />
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/debezium-connector-planetscale-private.iml
+++ b/.idea/debezium-connector-planetscale-private.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
This is an attempt at fixing CI. The CI has been failing with this error:
```
Run step-security/paths-filter@6eee183b0d2fd101d3f8ee2935c127bca14c5625
Error: Subscription is not valid. Reach out to support@stepsecurity.io
```
