### PR TITLE
update README.md, Apache 2.0 license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,2 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-This repo contains private source code and is not licensed for public use.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor
+      be liable to You for damages, including any direct, indirect,
+      special, incidental, or consequential damages of any character
+      arising as a result of this License or out of the use or inability
+      to use the Work (including but not limited to damages for loss of
+      goodwill, work stoppage, computer failure or malfunction, or any
+      and all other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,42 @@
 ![](./docs/images/planetscale-debezium-dark.png#gh-dark-mode-only)
 ![](./docs/images/planetscale-debezium-light.png#gh-light-mode-only)
 
-# Planetscale × Debezium
-
-> [Planetscale][0] Connector for [Debezium][1] `3.2.1.Final`
+# Debezium Connector for PlanetScale
 
 [![CI](https://github.com/sgammon/debezium-connector-planetscale-v2/actions/workflows/on.push.yml/badge.svg)](https://github.com/sgammon/debezium-connector-planetscale-v2/actions/workflows/on.push.yml)
 ![Java 21](https://img.shields.io/badge/Java-21-blue?style=flat&logoColor=white)
 ![Debezium 3.2.1.Final](https://img.shields.io/badge/Debezium-3.2.1.Final-blue?style=flat&logoColor=white)
-<a href="https://github.com/elide-dev/elide"><img src="https://img.shields.io/badge/Contributor%20Covenant-v1.4-ff69b4.svg" alt="Code of Conduct" /></a>
-![SLSA](https://img.shields.io/badge/SLSA-white?logoColor=white&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB2aWV3Qm94PSIwIDAgMjggMjgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI%2BPGRlZnM%2BPGNsaXBQYXRoIGlkPSJjbGlwMF8xMjNfMTEyNyI%2BPHBhdGggZD0iTTAgNS42QzAgMi41MDcyMSAyLjUwNzIxIDAgNS42IDBIMjIuNEMyNS40OTI4IDAgMjggMi41MDcyMSAyOCA1LjZWMjIuNEMyOCAyNS40OTI4IDI1LjQ5MjggMjggMjIuNCAyOEg1LjZDMi41MDcyMSAyOCAwIDI1LjQ5MjggMCAyMi40VjUuNloiIGZpbGw9IndoaXRlIi8%2BPC9jbGlwUGF0aD48L2RlZnM%2BPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzEyM18xMTI3KSIgdHJhbnNmb3JtPSJtYXRyaXgoMSwgMCwgMCwgMSwgLTguODgxNzg0MTk3MDAxMjUyZS0xNiwgLTMuNTUyNzEzNjc4ODAwNTAxZS0xNSkiPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjYuMTA1MiAzLjA2MzY4ZS0wNUwyNi4xODIyIC0wLjA4NzA1NTdMMjQuNjgzNiAtMS40MTE1TDI0LjAyMTQgLTAuNjYyMTkxQzIzLjgyMzcgLTAuNDM4NTA2IDIzLjYyMzIgLTAuMjE3NzUyIDIzLjQxOTkgMy4wNjM2OGUtMDVIMi44NjEwMmUtMDZWMS41NTg0MUwtMS4zNzU5OCAyLjQwNjQ2TC0wLjg1MTI5NyAzLjI1Nzc2Qy0wLjU3NjYwMiAzLjcwMzQ2IC0wLjI5MjcyNyA0LjE0MTY4IDIuODYxMDJlLTA2IDQuNTcyMjRWMjMuMjU2NEMtMC4wMDY3ODE4MiAyMy4yNTY2IC0wLjAxMzU2NjkgMjMuMjU2NyAtMC4wMjAzNTIxIDIzLjI1NjlMLTEuMDIwMTQgMjMuMjc3MkwtMC45Nzk0MzUgMjUuMjc2OEwyLjg2MTAyZS0wNiAyNS4yNTY5VjI4SDI4VjEwLjI2MzJDMjguMjg4MSA5Ljg0ODU1IDI4LjU2NzkgOS40MjY2MiAyOC44MzkyIDguOTk3NTlDMjkuMjk0OSA4LjMxMTczIDI5LjYzMzMgNy43MjUzMiAyOS44NTk4IDcuMzA2QzI5Ljk3MzcgNy4wOTUyMSAzMC4wNTk1IDYuOTI2MjkgMzAuMTE3OCA2LjgwNzc2QzMwLjE0NyA2Ljc0ODQ5IDMwLjE2OTMgNi43MDE3OCAzMC4xODQ5IDYuNjY4N0wzMC4yMDMyIDYuNjI5NDJMMzAuMjA4NiA2LjYxNzY5TDMwLjIxMDQgNi42MTM4NEwzMC4yMTEgNi42MTI0M0wzMC4yMTEzIDYuNjExODVMMzAuMjExNCA2LjYxMTU5QzMwLjIxMTQgNi42MTE0OCAzMC4yMTE1IDYuNjExMzYgMjkuMzU1NyA2LjIyNTE1TDMwLjIxMTUgNi42MTEzNkwzMC42MjI4IDUuNjk5ODdMMjguNzk5OCA0Ljg3NzIyTDI4LjM4OSA1Ljc4NzU4TDI4LjM4ODkgNS43ODc3OUwyOC4zODg4IDUuNzg3OTdMMjguMzg4NyA1Ljc4ODNMMjguMzg4NiA1Ljc4ODQ5TDI4LjM4ODUgNS43ODg3TDI4LjM4NjkgNS43OTIxOUwyOC4zNzU2IDUuODE2NTFDMjguMzY0NyA1LjgzOTUgMjguMzQ3NCA1Ljg3NTgzIDI4LjMyMzQgNS45MjQ0OEMyOC4yNzU1IDYuMDIxOCAyOC4yMDEzIDYuMTY4MjQgMjguMTAwMiA2LjM1NTQ4QzI4LjA2OTMgNi40MTI2NyAyOC4wMzU5IDYuNDczNjIgMjggNi41MzgxMVYzLjA2MzY4ZS0wNUgyNi4xMDUyWk0yNi4xMDUyIDMuMDYzNjhlLTA1SDIzLjQxOTlDMTkuMDEwNiA0LjcyMzcgMTMuMzAxNSA4LjA0OTI3IDcuMDIxNTMgOS41NTU4QzQuNjQ2NTcgNy40NDc2NyAyLjU2MDU2IDQuOTgxNjkgMC44NTEzMDMgMi4yMDg0TDAuMzI2NjIzIDEuMzU3MUwyLjg2MTAyZS0wNiAxLjU1ODQxVjQuNTcyMjRDMS43NDE1MyA3LjEzMzczIDMuNzk2NDggOS40MjQgNi4wOTY0NyAxMS40MDM1QzkuNDAyNDQgMTQuMjQ4NyAxMy4yMTQ3IDE2LjQ1MTggMTcuMzMwNCAxNy44OTU2QzEzLjg0NTcgMjAuMTczMSA5LjkzNzk1IDIxLjc4NTMgNS44MDgwMSAyMi42MTY2QzMuOTEyNTIgMjIuOTk4MSAxLjk3MDA4IDIzLjIxNTEgMi44NjEwMmUtMDYgMjMuMjU2NFYyNS4yNTY5TDAuMDIwMzU3OCAyNS4yNTY0QzIuMTE3MTcgMjUuMjEzOCA0LjE4NDg5IDI0Ljk4MzQgNi4yMDI2NCAyNC41NzcyQzExLjI4MzIgMjMuNTU0NiAxNi4wNDYxIDIxLjQxODEgMjAuMTU5NyAxOC4zNTkzQzIzLjE2MTggMTYuMTI3MSAyNS44MTgzIDEzLjQwMzUgMjggMTAuMjYzMlY2LjUzODExQzI3LjgwMDcgNi44OTYyNiAyNy41MjQxIDcuMzYzNTEgMjcuMTY3NCA3Ljg5OTcxTDI3LjE2MDkgNy45MDk1MkwyNy4xNTQ2IDcuOTE5NDhDMjUuMDUyMiAxMS4yNDczIDIyLjQwMjggMTQuMTIyNiAxOS4zNjIxIDE2LjQ1NTRDMTUuNTg1OSAxNS4zMTM2IDEyLjA1MTMgMTMuNTAzOCA4LjkyNjI4IDExLjEyM0MxNS4zMjI3IDkuMjk3MTkgMjEuMDkxNSA1LjY3MzA5IDI1LjUyIDAuNjYyMjUyTDI2LjEwNTIgMy4wNjM2OGUtMDVaIiBmaWxsPSIjRkY2NzQwIi8%2BPC9nPjwvc3ZnPg%3D%3D&link=https%3A%2F%2Fslsa.dev) ![SPDX](https://img.shields.io/badge/SPDX-white?logoColor=white&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48c3ZnIHZpZXdCb3g9IjAgMCA1MiA1MiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9InBhaW50MF9saW5lYXJfMTk3OV8zOTgiIHgxPSI4LjQ4NTgxIiB5MT0iNS4yMDgwNiIgeDI9IjI3LjcwMzQiIHkyPSIyOS42MTc3IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI%2BPHN0b3Agc3RvcC1jb2xvcj0id2hpdGUiIHN0b3Atb3BhY2l0eT0iMCIvPjxzdG9wIG9mZnNldD0iMC4zNDk0IiBzdG9wLWNvbG9yPSIjQ0RDQ0NDIiBzdG9wLW9wYWNpdHk9IjAuMjI2NjgiLz48c3RvcCBvZmZzZXQ9IjAuODg5IiBzdG9wLWNvbG9yPSIjNDU0MTQyIiBzdG9wLW9wYWNpdHk9IjAuODQ2OTgiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyMzFGMjAiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cGF0aCBkPSJNMTMuMzA0MiAxNC42NjhIMzYuNDUwMUw0NS45Njc2IDUuMDI2NzNIMy43MjU2NVY1LjE4NTczVjE0LjU1N1Y0Ny40OTdMMTMuMzA0MiAzNy45MTY1VjE0LjY2OFoiIGZpbGw9IiMwMDM3NzgiLz48cGF0aCBvcGFjaXR5PSIwLjgiIGQ9Ik0xMy4zMDQyIDE0LjY2OEgzNi40NTAxTDQ1Ljk2NzYgNS4wMjY3M0gzLjcyNTY1VjUuMTg1NzNWMTQuNTU3VjQ3LjQ5N0wxMy4zMDQyIDM3LjkxNjVWMTQuNjY4WiIgZmlsbD0idXJsKCNwYWludDBfbGluZWFyXzE5NzlfMzk4KSIvPjxwYXRoIGQ9Ik0zNi40NTAxIDE0LjY2NzlMMTMuMzA0MiAzNy45MTY0TDMuNzI1NjUgNDcuNTA4MkgxMy4zMDQySDE3LjY3ODlMMjYuMTc1NSAzOC44MTk0VjMwLjA5MzJWMjcuNjIzNEgyOC42Nzc3SDM3LjM0NUw0NS45MzE4IDE5LjAxNzlWMTQuNjY3OVY0Ljk3NzE3TDM2LjQ1MDEgMTQuNjY3OVoiIGZpbGw9IiMwMDk0RkYiLz48cGF0aCBkPSJNMjguNTcwNCAzMC4wMzMyVjM2LjQyNFY0Ny41MDgySDQ1LjkzMThWMzAuMDMzMkgzNC45NjU4SDI4LjU3MDRaIiBmaWxsPSIjMDA5NEZGIi8%2BPC9zdmc%2B&link=https%3A%2F%2Fspdx.dev) ![Sigstore](http://elide.dev/badge/sigstore)
+[![License](https://img.shields.io/badge/license-Apache--2.0-brightgreen.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
-## Usage
+This repository contains the [Debezium](https://debezium.io/) connector for PlanetScale. It is based on the [Debezium Vitess connector](https://debezium.io/documentation/reference/stable/connectors/vitess.html) and packages the PlanetScale-specific connector classes, patches, and runtime dependencies for Kafka Connect and Debezium Server.
 
-1) Install `https://planetscale-maven.elide.dev` as a Maven repository in your project.
-   ```kotlin
-   repositories {
-     maven {
-       name = "planetscale-debezium"
-       url = uri("https://planetscale-maven.elide.dev/")
-       content {
-         includeGroup("com.planetscale.labs")
-       }
-     }
-   }
-   ```
-2) Add a dependency on `com.planetscale.labs:debezium-planetscale`.
-   ```kotlin
-   dependencies {
-     implementation("com.planetscale.labs:debezium-planetscale:3.2.1.Final")
-   }
-   ```
-3) ???
-4) The adapter shows up as a Kafka Connect source connector (PROFIT!)
+## Build
 
-See [architecture docs](./docs/README.md) for an explanation of how the connector works.
+Requires Java 21.
 
-[0]: https://planetscale.com
-[1]: https://debezium.io
+```bash
+./gradlew build
+```
+
+The build produces the following artifacts under `debezium-planetscale/build/`:
+
+| Modality | Artifact | Shading |
+| --- | --- | --- |
+| Debezium Server | `libs/planetscale-debezium-adapter-<version>.jar` | Partially |
+| Debezium Server | `libs/planetscale-debezium-adapter-<version>-all.jar` | Fully |
+| Kafka Connect | `connect/dist/planetscale-debezium-connector-planetscale-<version>.zip` | Partially |
+
+## Run
+
+Use the Debezium Server helper in [`./server`](./server).
+
+```bash
+cp server/sample-application.properties server/ps.properties
+# edit server/ps.properties with your PlanetScale credentials and source settings
+./gradlew build
+make -C server run
+```
+
+## Documentation
+
+https://planetscale.com/docs/vitess/integrations/debezium#debezium-connector-for-planetscale

--- a/debezium-planetscale/src/main/config/README.md
+++ b/debezium-planetscale/src/main/config/README.md
@@ -1,40 +1,34 @@
-![](./docs/images/planetscale-debezium-dark.png#gh-dark-mode-only)
-![](./docs/images/planetscale-debezium-light.png#gh-light-mode-only)
+# Debezium Connector for PlanetScale
 
-# Planetscale × Debezium
+This package contains the [Debezium](https://debezium.io/) connector for PlanetScale. It is based on the [Debezium Vitess connector](https://debezium.io/documentation/reference/stable/connectors/vitess.html) and packages the PlanetScale-specific connector classes, patches, and runtime dependencies for Kafka Connect and Debezium Server.
 
-> [Planetscale][0] Connector for [Debezium][1] `3.2.1.Final`
+## Build
 
-[![CI](https://github.com/sgammon/debezium-connector-planetscale-v2/actions/workflows/on.push.yml/badge.svg)](https://github.com/sgammon/debezium-connector-planetscale-v2/actions/workflows/on.push.yml)
-![Java 21](https://img.shields.io/badge/Java-21-blue?style=flat&logoColor=white)
-![Debezium 3.2.1.Final](https://img.shields.io/badge/Debezium-3.2.1.Final-blue?style=flat&logoColor=white)
-<a href="https://github.com/elide-dev/elide"><img src="https://img.shields.io/badge/Contributor%20Covenant-v1.4-ff69b4.svg" alt="Code of Conduct" /></a>
-![SLSA](https://img.shields.io/badge/SLSA-white?logoColor=white&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB2aWV3Qm94PSIwIDAgMjggMjgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI%2BPGRlZnM%2BPGNsaXBQYXRoIGlkPSJjbGlwMF8xMjNfMTEyNyI%2BPHBhdGggZD0iTTAgNS42QzAgMi41MDcyMSAyLjUwNzIxIDAgNS42IDBIMjIuNEMyNS40OTI4IDAgMjggMi41MDcyMSAyOCA1LjZWMjIuNEMyOCAyNS40OTI4IDI1LjQ5MjggMjggMjIuNCAyOEg1LjZDMi41MDcyMSAyOCAwIDI1LjQ5MjggMCAyMi40VjUuNloiIGZpbGw9IndoaXRlIi8%2BPC9jbGlwUGF0aD48L2RlZnM%2BPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzEyM18xMTI3KSIgdHJhbnNmb3JtPSJtYXRyaXgoMSwgMCwgMCwgMSwgLTguODgxNzg0MTk3MDAxMjUyZS0xNiwgLTMuNTUyNzEzNjc4ODAwNTAxZS0xNSkiPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjYuMTA1MiAzLjA2MzY4ZS0wNUwyNi4xODIyIC0wLjA4NzA1NTdMMjQuNjgzNiAtMS40MTE1TDI0LjAyMTQgLTAuNjYyMTkxQzIzLjgyMzcgLTAuNDM4NTA2IDIzLjYyMzIgLTAuMjE3NzUyIDIzLjQxOTkgMy4wNjM2OGUtMDVIMi44NjEwMmUtMDZWMS41NTg0MUwtMS4zNzU5OCAyLjQwNjQ2TC0wLjg1MTI5NyAzLjI1Nzc2Qy0wLjU3NjYwMiAzLjcwMzQ2IC0wLjI5MjcyNyA0LjE0MTY4IDIuODYxMDJlLTA2IDQuNTcyMjRWMjMuMjU2NEMtMC4wMDY3ODE4MiAyMy4yNTY2IC0wLjAxMzU2NjkgMjMuMjU2NyAtMC4wMjAzNTIxIDIzLjI1NjlMLTEuMDIwMTQgMjMuMjc3MkwtMC45Nzk0MzUgMjUuMjc2OEwyLjg2MTAyZS0wNiAyNS4yNTY5VjI4SDI4VjEwLjI2MzJDMjguMjg4MSA5Ljg0ODU1IDI4LjU2NzkgOS40MjY2MiAyOC44MzkyIDguOTk3NTlDMjkuMjk0OSA4LjMxMTczIDI5LjYzMzMgNy43MjUzMiAyOS44NTk4IDcuMzA2QzI5Ljk3MzcgNy4wOTUyMSAzMC4wNTk1IDYuOTI2MjkgMzAuMTE3OCA2LjgwNzc2QzMwLjE0NyA2Ljc0ODQ5IDMwLjE2OTMgNi43MDE3OCAzMC4xODQ5IDYuNjY4N0wzMC4yMDMyIDYuNjI5NDJMMzAuMjA4NiA2LjYxNzY5TDMwLjIxMDQgNi42MTM4NEwzMC4yMTEgNi42MTI0M0wzMC4yMTEzIDYuNjExODVMMzAuMjExNCA2LjYxMTU5QzMwLjIxMTQgNi42MTE0OCAzMC4yMTE1IDYuNjExMzYgMjkuMzU1NyA2LjIyNTE1TDMwLjIxMTUgNi42MTEzNkwzMC42MjI4IDUuNjk5ODdMMjguNzk5OCA0Ljg3NzIyTDI4LjM4OSA1Ljc4NzU4TDI4LjM4ODkgNS43ODc3OUwyOC4zODg4IDUuNzg3OTdMMjguMzg4NyA1Ljc4ODNMMjguMzg4NiA1Ljc4ODQ5TDI4LjM4ODUgNS43ODg3TDI4LjM4NjkgNS43OTIxOUwyOC4zNzU2IDUuODE2NTFDMjguMzY0NyA1LjgzOTUgMjguMzQ3NCA1Ljg3NTgzIDI4LjMyMzQgNS45MjQ0OEMyOC4yNzU1IDYuMDIxOCAyOC4yMDEzIDYuMTY4MjQgMjguMTAwMiA2LjM1NTQ4QzI4LjA2OTMgNi40MTI2NyAyOC4wMzU5IDYuNDczNjIgMjggNi41MzgxMVYzLjA2MzY4ZS0wNUgyNi4xMDUyWk0yNi4xMDUyIDMuMDYzNjhlLTA1SDIzLjQxOTlDMTkuMDEwNiA0LjcyMzcgMTMuMzAxNSA4LjA0OTI3IDcuMDIxNTMgOS41NTU4QzQuNjQ2NTcgNy40NDc2NyAyLjU2MDU2IDQuOTgxNjkgMC44NTEzMDMgMi4yMDg0TDAuMzI2NjIzIDEuMzU3MUwyLjg2MTAyZS0wNiAxLjU1ODQxVjQuNTcyMjRDMS43NDE1MyA3LjEzMzczIDMuNzk2NDggOS40MjQgNi4wOTY0NyAxMS40MDM1QzkuNDAyNDQgMTQuMjQ4NyAxMy4yMTQ3IDE2LjQ1MTggMTcuMzMwNCAxNy44OTU2QzEzLjg0NTcgMjAuMTczMSA5LjkzNzk1IDIxLjc4NTMgNS44MDgwMSAyMi42MTY2QzMuOTEyNTIgMjIuOTk4MSAxLjk3MDA4IDIzLjIxNTEgMi44NjEwMmUtMDYgMjMuMjU2NFYyNS4yNTY5TDAuMDIwMzU3OCAyNS4yNTY0QzIuMTE3MTcgMjUuMjEzOCA0LjE4NDg5IDI0Ljk4MzQgNi4yMDI2NCAyNC41NzcyQzExLjI4MzIgMjMuNTU0NiAxNi4wNDYxIDIxLjQxODEgMjAuMTU5NyAxOC4zNTkzQzIzLjE2MTggMTYuMTI3MSAyNS44MTgzIDEzLjQwMzUgMjggMTAuMjYzMlY2LjUzODExQzI3LjgwMDcgNi44OTYyNiAyNy41MjQxIDcuMzYzNTEgMjcuMTY3NCA3Ljg5OTcxTDI3LjE2MDkgNy45MDk1MkwyNy4xNTQ2IDcuOTE5NDhDMjUuMDUyMiAxMS4yNDczIDIyLjQwMjggMTQuMTIyNiAxOS4zNjIxIDE2LjQ1NTRDMTUuNTg1OSAxNS4zMTM2IDEyLjA1MTMgMTMuNTAzOCA4LjkyNjI4IDExLjEyM0MxNS4zMjI3IDkuMjk3MTkgMjEuMDkxNSA1LjY3MzA5IDI1LjUyIDAuNjYyMjUyTDI2LjEwNTIgMy4wNjM2OGUtMDVaIiBmaWxsPSIjRkY2NzQwIi8%2BPC9nPjwvc3ZnPg%3D%3D&link=https%3A%2F%2Fslsa.dev) ![SPDX](https://img.shields.io/badge/SPDX-white?logoColor=white&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48c3ZnIHZpZXdCb3g9IjAgMCA1MiA1MiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9InBhaW50MF9saW5lYXJfMTk3OV8zOTgiIHgxPSI4LjQ4NTgxIiB5MT0iNS4yMDgwNiIgeDI9IjI3LjcwMzQiIHkyPSIyOS42MTc3IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI%2BPHN0b3Agc3RvcC1jb2xvcj0id2hpdGUiIHN0b3Atb3BhY2l0eT0iMCIvPjxzdG9wIG9mZnNldD0iMC4zNDk0IiBzdG9wLWNvbG9yPSIjQ0RDQ0NDIiBzdG9wLW9wYWNpdHk9IjAuMjI2NjgiLz48c3RvcCBvZmZzZXQ9IjAuODg5IiBzdG9wLWNvbG9yPSIjNDU0MTQyIiBzdG9wLW9wYWNpdHk9IjAuODQ2OTgiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyMzFGMjAiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cGF0aCBkPSJNMTMuMzA0MiAxNC42NjhIMzYuNDUwMUw0NS45Njc2IDUuMDI2NzNIMy43MjU2NVY1LjE4NTczVjE0LjU1N1Y0Ny40OTdMMTMuMzA0MiAzNy45MTY1VjE0LjY2OFoiIGZpbGw9IiMwMDM3NzgiLz48cGF0aCBvcGFjaXR5PSIwLjgiIGQ9Ik0xMy4zMDQyIDE0LjY2OEgzNi40NTAxTDQ1Ljk2NzYgNS4wMjY3M0gzLjcyNTY1VjUuMTg1NzNWMTQuNTU3VjQ3LjQ5N0wxMy4zMDQyIDM3LjkxNjVWMTQuNjY4WiIgZmlsbD0idXJsKCNwYWludDBfbGluZWFyXzE5NzlfMzk4KSIvPjxwYXRoIGQ9Ik0zNi40NTAxIDE0LjY2NzlMMTMuMzA0MiAzNy45MTY0TDMuNzI1NjUgNDcuNTA4MkgxMy4zMDQySDE3LjY3ODlMMjYuMTc1NSAzOC44MTk0VjMwLjA5MzJWMjcuNjIzNEgyOC42Nzc3SDM3LjM0NUw0NS45MzE4IDE5LjAxNzlWMTQuNjY3OVY0Ljk3NzE3TDM2LjQ1MDEgMTQuNjY3OVoiIGZpbGw9IiMwMDk0RkYiLz48cGF0aCBkPSJNMjguNTcwNCAzMC4wMzMyVjM2LjQyNFY0Ny41MDgySDQ1LjkzMThWMzAuMDMzMkgzNC45NjU4SDI4LjU3MDRaIiBmaWxsPSIjMDA5NEZGIi8%2BPC9zdmc%2B&link=https%3A%2F%2Fspdx.dev) ![Sigstore](http://elide.dev/badge/sigstore)
+From the repository root:
 
-## Usage
+```bash
+./gradlew build
+```
 
-1) Install `https://planetscale-maven.elide.dev` as a Maven repository in your project.
-   ```kotlin
-   repositories {
-     maven {
-       name = "planetscale-debezium"
-       url = uri("https://planetscale-maven.elide.dev/")
-       content {
-         includeGroup("com.planetscale.labs")
-       }
-     }
-   }
-   ```
-2) Add a dependency on `com.planetscale.labs:debezium-planetscale`.
-   ```kotlin
-   dependencies {
-     implementation("com.planetscale.labs:debezium-planetscale:3.2.1.Final")
-   }
-   ```
-3) ???
-4) The adapter shows up as a Kafka Connect source connector (PROFIT!)
+The build produces the following artifacts under `debezium-planetscale/build/`:
 
-See [architecture docs](./docs/README.md) for an explanation of how the connector works.
+| Modality | Artifact | Shading |
+| --- | --- | --- |
+| Debezium Server | `libs/planetscale-debezium-adapter-<version>.jar` | Partially |
+| Debezium Server | `libs/planetscale-debezium-adapter-<version>-all.jar` | Fully |
+| Kafka Connect | `connect/dist/planetscale-debezium-connector-planetscale-<version>.zip` | Partially |
 
-[0]: https://planetscale.com
-[1]: https://debezium.io
+## Run
+
+For local Debezium Server usage, see `./server` in the source repository.
+
+```bash
+cp server/sample-application.properties server/ps.properties
+# edit server/ps.properties with your PlanetScale credentials and source settings
+./gradlew build
+make -C server run
+```
+
+## Documentation
+
+https://planetscale.com/docs/vitess/integrations/debezium#debezium-connector-for-planetscale


### PR DESCRIPTION
Update `README.md` to be slightly more useful, and switch from unlicensed to Apache license, which is what upstream Debezium uses.