### PR TITLE
build(connect): inject version + release_date into manifest.json

### DIFF
--- a/debezium-planetscale/build.gradle.kts
+++ b/debezium-planetscale/build.gradle.kts
@@ -13,6 +13,8 @@ import net.bytebuddy.build.gradle.Adjustment
 import net.bytebuddy.build.gradle.Adjustment.ErrorHandler
 import net.bytebuddy.build.gradle.ByteBuddyTask
 import net.bytebuddy.build.gradle.Discovery
+import org.apache.tools.ant.filters.ReplaceTokens
+import java.time.LocalDate
 
 plugins {
   application
@@ -33,6 +35,11 @@ plugins {
 val packagePrefix = PlanetscaleBuild.PACKAGE_GROUP
 val vitessPackage = "io.debezium.connector.vitess"
 val mysqlPackage = "io.debezium.connector.mysql"
+
+// Values injected into the Connect manifest.json at package time so they never go stale:
+//   version      -> the full project version (e.g. 3.2.1.Final-r2), matching the artifact
+//   release_date -> the build date (ISO yyyy-MM-dd), overridable with -PreleaseDate=YYYY-MM-DD
+val manifestReleaseDate: String = providers.gradleProperty("releaseDate").orNull ?: LocalDate.now().toString()
 
 val enableSigning = findProperty("planetscale.release") == "true"
 val enableSigstore = findProperty("planetscale.sigstore") == "true"
@@ -243,6 +250,11 @@ val assembleConnectLib by tasks.registering(Copy::class) {
 val assembleConnectLayout by tasks.registering(Copy::class) {
   from(layout.projectDirectory.dir("src/main/config")) {
     include("manifest.json")
+    // inject @version@ / @release_date@ so the manifest always matches the built artifact
+    filter(
+      mapOf("tokens" to mapOf("version" to project.version.toString(), "release_date" to manifestReleaseDate)),
+      ReplaceTokens::class.java,
+    )
   }
   into(connectOut.get())
 

--- a/debezium-planetscale/src/main/config/manifest.json
+++ b/debezium-planetscale/src/main/config/manifest.json
@@ -1,6 +1,6 @@
 {
   "name" : "debezium-connector-planetscale",
-  "version" : "3.2.1.Final",
+  "version" : "@version@",
   "title" : "Debezium Connector for PlanetScale",
   "description" : "Debezium connector for Planetscale, a serverless database powered by Vitess",
   "owner" : {
@@ -21,5 +21,5 @@
     "url" : "http://www.apache.org/licenses/LICENSE-2.0"
   } ],
   "component_types" : [ "source" ],
-  "release_date" : "2025-08-14"
+  "release_date" : "@release_date@"
 }


### PR DESCRIPTION
## What
Template the Kafka Connect plugin `manifest.json` so the build injects `version` and `release_date` at package time, instead of shipping hardcoded values.

## Why
The shipped `manifest.json` had:
- `version: "3.2.1.Final"` — missing the connector revision, so it didn't match the artifact (`…-r2`).
- `release_date: "2025-08-14"` — a stale hardcoded date.

Both had to be updated by hand and were already wrong on the current draft release.

## How
- `manifest.json` now uses `@version@` / `@release_date@` tokens.
- `assembleConnectLayout` filters them (Ant `ReplaceTokens`) with `project.version` (e.g. `3.2.1.Final-r2`) and the build date, overridable via `-PreleaseDate=YYYY-MM-DD`.

Verified: the built connector zip's `manifest.json` shows `"version": "3.2.1.Final-r2"` and the build date; `-PreleaseDate=2026-07-10` override was honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
