### PR TITLE
fix(vitess): carry upstream BIT column fix (debezium/dbz#2191)

### DIFF
--- a/debezium-planetscale/api/debezium-planetscale.api
+++ b/debezium-planetscale/api/debezium-planetscale.api
@@ -143,8 +143,26 @@ public class io/debezium/connector/vitess/VitessMetadata {
 	protected static fun parseRows (Ljava/util/List;)Ljava/util/List;
 }
 
+public class io/debezium/connector/vitess/VitessType {
+	public fun <init> (Ljava/lang/String;I)V
+	public fun <init> (Ljava/lang/String;ILjava/lang/Integer;)V
+	public fun <init> (Ljava/lang/String;ILjava/util/List;)V
+	public fun <init> (Ljava/lang/String;ILjava/util/List;Ljava/util/Optional;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEnumValues ()Ljava/util/List;
+	public fun getJdbcId ()I
+	public fun getName ()Ljava/lang/String;
+	public fun getPrecision ()Ljava/util/Optional;
+	public fun hashCode ()I
+	public fun isEnum ()Z
+	public static fun resolve (Lio/vitess/proto/Query$Field;)Lio/debezium/connector/vitess/VitessType;
+	public static fun resolve (Lio/vitess/proto/Query$Field;Z)Lio/debezium/connector/vitess/VitessType;
+	public fun toString ()Ljava/lang/String;
+}
+
 public class io/debezium/connector/vitess/VitessValueConverter : io/debezium/jdbc/JdbcValueConverters {
 	public fun <init> (Lio/debezium/jdbc/JdbcValueConverters$DecimalMode;Lio/debezium/jdbc/TemporalPrecisionMode;Ljava/time/ZoneOffset;Lio/debezium/config/CommonConnectorConfig$BinaryHandlingMode;ZLio/debezium/connector/vitess/VitessConnectorConfig$BigIntUnsignedHandlingMode;ZLjava/time/temporal/TemporalAdjuster;Lio/debezium/config/CommonConnectorConfig$EventConvertingFailureHandlingMode;Lio/debezium/service/spi/ServiceRegistry;)V
+	protected fun convertBits (Lio/debezium/relational/Column;Lorg/apache/kafka/connect/data/Field;)Lio/debezium/relational/ValueConverter;
 	protected fun convertGeometry (Lio/debezium/relational/Column;Lorg/apache/kafka/connect/data/Field;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun convertSetToString (Ljava/util/List;Lio/debezium/relational/Column;Lorg/apache/kafka/connect/data/Field;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun convertSetValue (Lio/debezium/relational/Column;JLjava/util/List;)Ljava/lang/String;
@@ -159,6 +177,11 @@ public class io/debezium/connector/vitess/VitessValueConverter : io/debezium/jdb
 	public static fun stringToDuration (Ljava/lang/String;)Ljava/time/Duration;
 	public static fun stringToLocalDate (Ljava/lang/String;)Ljava/time/LocalDate;
 	public static fun stringToTimestamp (Ljava/lang/String;)Ljava/sql/Timestamp;
+}
+
+public class io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver {
+	public fun <init> ()V
+	public static fun resolveValue (Lio/debezium/connector/vitess/VitessType;Lio/debezium/connector/vitess/connection/ReplicationMessage$ColumnValue;ZLio/debezium/jdbc/TemporalPrecisionMode;)Ljava/lang/Object;
 }
 
 public class io/debezium/connector/vitess/connection/VitessColumnValue : io/debezium/connector/vitess/connection/ReplicationMessage$ColumnValue {

--- a/debezium-planetscale/build.gradle.kts
+++ b/debezium-planetscale/build.gradle.kts
@@ -186,6 +186,10 @@ val debeziumClasses by tasks.registering(Copy::class) {
   exclude("**/VitessValueConverter*") // fix: custom type support (geo)
   exclude("**/VitessDatabaseSchema*") // fix: custom type support (geo)
   exclude("**/VitessConnectorConfig*") // fix: overrides for cell hint, etc
+  // fix: BIT columns silently dropped (upstream debezium/dbz#2191, merged for 3.7); drop these
+  // two excludes + fork copies once we build against a release that contains the fix.
+  exclude("**/VitessType*") // fix: BIT -> Types.BIT mapping with column width
+  exclude("**/connection/ReplicationMessageColumnValueResolver*") // fix: Types.BIT -> asBytes()
   exclude("**/VitessMetadata*") // fix: backtick-quote keyspace identifiers (e.g. hyphenated names)
   finalizedBy(debeziumClassesPatched)
 }

--- a/debezium-planetscale/src/main/java/io/debezium/connector/vitess/VitessType.java
+++ b/debezium-planetscale/src/main/java/io/debezium/connector/vitess/VitessType.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.vitess;
+
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.vitess.proto.Query;
+
+/** The Vitess table column type */
+public class VitessType {
+
+    // name of the column type
+    private final String name;
+    // enum of column jdbc type
+    private final int jdbcId;
+    // permitted enum values
+    private final List<String> enumValues;
+    private Optional<Integer> precision;
+
+    public VitessType(String name, int jdbcId) {
+        this(name, jdbcId, Collections.emptyList());
+    }
+
+    public VitessType(String name, int jdbcId, List<String> enumValues) {
+        this(name, jdbcId, enumValues, Optional.empty());
+    }
+
+    public VitessType(String name, int jdbcId, Integer precision) {
+        this(name, jdbcId, Collections.emptyList(), Optional.of(precision));
+    }
+
+    public VitessType(String name, int jdbcId, List<String> enumValues, Optional<Integer> precision) {
+        this.name = name;
+        this.jdbcId = jdbcId;
+        this.enumValues = Collections.unmodifiableList(enumValues);
+        this.precision = precision;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getJdbcId() {
+        return jdbcId;
+    }
+
+    public List<String> getEnumValues() {
+        return enumValues;
+    }
+
+    public boolean isEnum() {
+        return !enumValues.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return "VitessType{" +
+                "name='" + name + '\'' +
+                ", jdbcId=" + jdbcId +
+                ", enumValues=" + enumValues +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VitessType that = (VitessType) o;
+        return jdbcId == that.jdbcId && name.equals(that.name) && Objects.equals(enumValues, that.enumValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, jdbcId, enumValues);
+    }
+
+    public static VitessType resolve(Query.Field field) {
+        return resolve(field, false);
+    }
+
+    // Resolve JDBC type from vstream FIELD event
+    public static VitessType resolve(Query.Field field, boolean isEnumSetStringValue) {
+        String type = field.getType().name();
+        switch (type) {
+            case "INT8":
+            case "UINT8":
+            case "INT16":
+                return new VitessType(type, Types.SMALLINT);
+            case "UINT16":
+            case "INT24":
+            case "UINT24":
+            case "INT32":
+            case "YEAR":
+                return new VitessType(type, Types.INTEGER);
+            case "ENUM":
+            case "SET":
+                return getEnumOrSetVitessType(isEnumSetStringValue, type, field);
+            case "UINT32":
+            case "INT64":
+                return new VitessType(type, Types.BIGINT);
+            case "BLOB":
+                if (matchAny(field, List.of("TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT"))) {
+                    return new VitessType(type, Types.VARCHAR);
+                }
+                return new VitessType(type, Types.BLOB);
+            case "VARBINARY":
+                if (VitessValueConverter.matches(field.getColumnType().toUpperCase(), "VARCHAR")) {
+                    return new VitessType(type, Types.VARCHAR);
+                }
+            case "BINARY":
+                if (VitessValueConverter.matches(field.getColumnType().toUpperCase(), "CHAR")) {
+                    return new VitessType(type, Types.VARCHAR);
+                }
+                else if (VitessValueConverter.matches(field.getColumnType().toUpperCase(), "ENUM")) {
+                    return getEnumOrSetVitessType(isEnumSetStringValue, "ENUM", field);
+                }
+                else if (VitessValueConverter.matches(field.getColumnType().toUpperCase(), "SET")) {
+                    return getEnumOrSetVitessType(isEnumSetStringValue, "SET", field);
+                }
+                return new VitessType(type, Types.BINARY);
+            case "UINT64":
+            case "VARCHAR":
+            case "CHAR":
+            case "TEXT":
+            case "JSON":
+            case "DECIMAL":
+                return new VitessType(type, Types.VARCHAR);
+            case "TIME":
+                return new VitessType(type, Types.TIME, field.getDecimals());
+            case "DATE":
+                return new VitessType(type, Types.DATE);
+            case "TIMESTAMP":
+                return new VitessType(type, Types.TIMESTAMP_WITH_TIMEZONE, field.getDecimals());
+            case "DATETIME":
+                return new VitessType(type, Types.TIMESTAMP, field.getDecimals());
+            case "FLOAT32":
+                return new VitessType(type, Types.FLOAT);
+            case "FLOAT64":
+                return new VitessType(type, Types.DOUBLE);
+            // fork copy + upstream fix debezium/dbz#2191 (PR #293):
+            // without this case BIT falls through to OTHER and the column is silently dropped
+            case "BIT":
+                return new VitessType(type, Types.BIT, field.getColumnLength());
+            default:
+                return new VitessType(type, Types.OTHER);
+        }
+    }
+
+    private static boolean matchAny(Query.Field field, List<String> types) {
+        String upperCaseType = field.getColumnType().toUpperCase();
+        return types.stream().filter(type -> VitessValueConverter.matches(upperCaseType, type)).findAny().isPresent();
+    }
+
+    private static VitessType getEnumOrSetVitessType(boolean isEnumSetStringValue, String type, Query.Field field) {
+        int jdbcType;
+        if (type.equals("ENUM") && !isEnumSetStringValue) {
+            jdbcType = Types.INTEGER;
+        }
+        else if (type.equals("SET") && !isEnumSetStringValue) {
+            // Set types can have at most 64 items, each item can be present or not, so total is 2^64 so need a BIGINT
+            jdbcType = Types.BIGINT;
+        }
+        else {
+            // This is only called when the column type matches either enum or set, so it must be the case that isEnumSetStringValue is true,
+            // so we should interpret the value as a string
+            jdbcType = Types.VARCHAR;
+        }
+        return new VitessType(type, jdbcType, resolveEnumAndSetValues(field.getColumnType()));
+    }
+
+    /**
+     * Resolve the list of permitted Enum or Set values from the Enum or Set Definition
+     * @param definition the Enum or Set column definition from the MySQL table. E.g. "enum('m','l','xl')" or "set('a','b','c')"
+     * @return The list of permitted Enum values or Set values
+     */
+    private static List<String> resolveEnumAndSetValues(String definition) {
+        List<String> values = new ArrayList<>();
+        if (definition == null || definition.length() == 0) {
+            return values;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        boolean startCollecting = false;
+        char[] chars = definition.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            if (chars[i] == '\'') {
+                if (chars[i + 1] != '\'') {
+                    if (startCollecting) {
+                        // end of the Enum/Set value, add the Enum/Set value to the result list
+                        values.add(sb.toString());
+                        sb.setLength(0);
+                    }
+                    startCollecting = !startCollecting;
+                }
+                else {
+                    sb.append("'");
+                    // In MySQL, the single quote in the Enum/Set definition "a'b" is escaped and becomes "a''b".
+                    // Skip the second single-quote
+                    i++;
+                }
+            }
+            else if (startCollecting) {
+                sb.append(chars[i]);
+            }
+        }
+        return values;
+    }
+
+    public Optional<Integer> getPrecision() {
+        return this.precision;
+    }
+}

--- a/debezium-planetscale/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
+++ b/debezium-planetscale/src/main/java/io/debezium/connector/vitess/VitessValueConverter.java
@@ -198,6 +198,23 @@ public class VitessValueConverter extends JdbcValueConverters {
     return matches(typeName, Query.Type.TIMESTAMP.name());
   }
 
+  // Ported from upstream debezium/dbz#2191 (PR #293); this fork copy shades out upstream's
+  // VitessValueConverter, so the fix must be carried here.
+  @Override
+  protected ValueConverter convertBits(Column column, Field fieldDefn) {
+    // VStream sends raw bytes; convert BIT(1) to boolean as JdbcValueConverters expects,
+    // return BIT(N) as-is for Kafka Connect BYTES schema
+    return (data) -> {
+      if (data instanceof byte[] bytes) {
+        if (column.length() <= 1) {
+          return bytes.length > 0 && bytes[0] != 0;
+        }
+        return bytes;
+      }
+      return super.convertBits(column, fieldDefn).convert(data);
+    };
+  }
+
   // Implements additional type support for the Planetscale adapter.
   private @Nullable ValueConverter superOrShimmedConverter(Column inputColumn, Field fieldDefn) {
     ValueConverter superConverter = super.converter(inputColumn, fieldDefn);

--- a/debezium-planetscale/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
+++ b/debezium-planetscale/src/main/java/io/debezium/connector/vitess/connection/ReplicationMessageColumnValueResolver.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.vitess.connection;
+
+import java.sql.Types;
+import java.util.Map;
+import java.util.function.Function;
+
+import io.debezium.connector.vitess.VitessType;
+import io.debezium.connector.vitess.VitessValueConverter;
+import io.debezium.jdbc.TemporalPrecisionMode;
+
+/** Resolve raw column value to Java value */
+public class ReplicationMessageColumnValueResolver {
+
+    private static Map<Integer, Function<String, Object>> temporalTypeToConverter = Map.of(
+            Types.TIME, VitessValueConverter::stringToDuration,
+            Types.DATE, VitessValueConverter::stringToLocalDate,
+            Types.TIMESTAMP, VitessValueConverter::stringToTimestamp);
+
+    public static Object resolveValue(VitessType vitessType,
+                                      ReplicationMessage.ColumnValue<byte[]> value,
+                                      boolean includeUnknownDatatypes,
+                                      TemporalPrecisionMode temporalPrecisionMode) {
+
+        if (value.isNull()) {
+            return null;
+        }
+
+        switch (vitessType.getJdbcId()) {
+            case Types.SMALLINT:
+                return value.asShort();
+            case Types.INTEGER:
+                return value.asInteger();
+            case Types.BIGINT:
+                return value.asLong();
+            // fork copy + upstream fix debezium/dbz#2191 (PR #293):
+            // BIT arrives from VStream as raw bytes; without this case it resolves to null
+            case Types.BIT:
+            case Types.BLOB:
+            case Types.BINARY:
+                return value.asBytes();
+            case Types.TIMESTAMP_WITH_TIMEZONE: // This is the case for TIMESTAMP which is simply treated as string
+            case Types.VARCHAR:
+                return value.asString();
+            case Types.FLOAT:
+                return value.asFloat();
+            case Types.DOUBLE:
+                return value.asDouble();
+            case Types.TIME:
+            case Types.TIMESTAMP: // This is a misnomer and is the case for DATETIME
+            case Types.DATE:
+                Function<String, Object> converter = temporalTypeToConverter.get(vitessType.getJdbcId());
+                return convertOrReturnString(converter, value, temporalPrecisionMode);
+            default:
+                break;
+        }
+
+        return value.asDefault(vitessType, includeUnknownDatatypes);
+    }
+
+    private static Object convertOrReturnString(Function<String, Object> converter,
+                                                ReplicationMessage.ColumnValue<byte[]> value,
+                                                TemporalPrecisionMode temporalPrecisionMode) {
+        String stringValue = value.asString();
+        if (temporalPrecisionMode.equals(TemporalPrecisionMode.ISOSTRING)) {
+            return stringValue;
+        }
+        else {
+            return converter.apply(stringValue);
+        }
+    }
+}

--- a/debezium-planetscale/src/test/kotlin/com/planetscale/debezium/VitessValueConverterBitTest.kt
+++ b/debezium-planetscale/src/test/kotlin/com/planetscale/debezium/VitessValueConverterBitTest.kt
@@ -1,0 +1,82 @@
+package com.planetscale.debezium
+
+import io.debezium.config.Configuration
+import io.debezium.connector.vitess.VitessConnectorConfig
+import io.debezium.connector.vitess.VitessValueConverter
+import io.debezium.relational.Column
+import java.sql.Types
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import org.apache.kafka.connect.data.Field
+
+// Covers the BIT column fix ported from upstream debezium/dbz#2191 (PR #293): VStream delivers BIT
+// values as raw bytes; BIT(1) must convert to boolean and BIT(N) must pass through as bytes for the
+// Kafka Connect BYTES schema. Before the fix the column was silently dropped from change events.
+internal class VitessValueConverterBitTest {
+
+  @Test fun convertsBit1ToTrue() {
+    val column = bitColumn(length = 1)
+    val field = Field(column.name(), 0, converter().schemaBuilder(column).build())
+    val converted = converter().converter(column, field).convert(byteArrayOf(1))
+    assertEquals(true, converted)
+  }
+
+  @Test fun convertsBit1ToFalse() {
+    val column = bitColumn(length = 1)
+    val field = Field(column.name(), 0, converter().schemaBuilder(column).build())
+    val converted = converter().converter(column, field).convert(byteArrayOf(0))
+    assertEquals(false, converted)
+  }
+
+  @Test fun passesBit8ThroughAsBytes() {
+    val column = bitColumn(length = 8)
+    val field = Field(column.name(), 0, converter().schemaBuilder(column).build())
+    val converted = converter().converter(column, field).convert(byteArrayOf(0xAA.toByte()))
+    assertContentEquals(byteArrayOf(0xAA.toByte()), converted as ByteArray)
+  }
+
+  @Test fun passesBit64ThroughAsBytes() {
+    val bytes = ByteArray(8) { 0xAA.toByte() }
+    val column = bitColumn(length = 64)
+    val field = Field(column.name(), 0, converter().schemaBuilder(column).build())
+    val converted = converter().converter(column, field).convert(bytes)
+    assertContentEquals(bytes, converted as ByteArray)
+  }
+
+  @Test fun buildsBooleanSchemaForBit1() {
+    val schema = converter().schemaBuilder(bitColumn(length = 1)).build()
+    assertEquals(org.apache.kafka.connect.data.Schema.Type.BOOLEAN, schema.type())
+  }
+
+  @Test fun buildsBytesSchemaForBit8() {
+    val schema = converter().schemaBuilder(bitColumn(length = 8)).build()
+    assertEquals(org.apache.kafka.connect.data.Schema.Type.BYTES, schema.type())
+    assertEquals(io.debezium.data.Bits.LOGICAL_NAME, schema.name())
+  }
+
+  private fun bitColumn(length: Int): Column = Column.editor()
+    .name("bit_col")
+    .type("BIT")
+    .jdbcType(Types.BIT)
+    .length(length)
+    .optional(true)
+    .create()
+
+  // Mirrors the construction in VitessDatabaseSchema, with default configuration.
+  private fun converter(): VitessValueConverter {
+    val config = VitessConnectorConfig(Configuration.create().build())
+    return VitessValueConverter(
+      config.getDecimalMode(),
+      config.getTemporalPrecisionMode(),
+      ZoneOffset.UTC,
+      config.binaryHandlingMode(),
+      config.includeUnknownDatatypes(),
+      config.getBigIntUnsgnedHandlingMode(),
+      config.overrideDatetimeToNullable(),
+      null,
+      config.getEventConvertingFailureHandlingMode(),
+      config.getServiceRegistry())
+  }
+}


### PR DESCRIPTION
## Summary

Backports the BIT-column fix merged upstream in [debezium/debezium-connector-vitess#293](https://github.com/debezium/debezium-connector-vitess/pull/293) ([dbz#2191](https://issues.redhat.com/browse/DBZ-2191)). Upstream ships it in 3.7; we build against 3.2.1.Final, so this carries the fix as fork copies until we move to a release that contains it.

**The bug:** BIT columns were silently dropped from change events. `VitessType.resolve()` had no case for the `BIT` type name (fell through to JDBC `OTHER`), and `ReplicationMessageColumnValueResolver.resolveValue()` had no `Types.BIT` arm (returned `null`).

## Changes

- **Fork copies** of `VitessType` (adds `BIT` → `Types.BIT` with the column width carried as precision) and `ReplicationMessageColumnValueResolver` (adds `Types.BIT` to the `asBytes()` arm), based on the v3.2.1.Final sources, with matching excludes in the `debeziumClasses` task — same pattern as the other five carried classes.
- **`convertBits` override** in our existing `VitessValueConverter` fork copy (it shades out upstream's class, so the upstream fix has to be carried here): VStream sends raw bytes, so BIT(1) converts to boolean and BIT(N) passes through as bytes for the Kafka Connect BYTES schema.
- **`VitessValueConverterBitTest`**: BIT(1) true/false conversion, BIT(8)/BIT(64) byte passthrough, and boolean/Bits schema mapping.

The excludes are commented as removable once we build against an upstream release containing the fix — at that point the two new fork copies get deleted, same as the `VitessMetadata` precedent.

## Verification

- `:debezium-planetscale:test` — 154 passing (incl. 6 new BIT tests).
- End-to-end in the debezium-server docker lab against a real PlanetScale branch with `BIT(1)/BIT(8)/BIT(64)` columns: **before** this fix the fields are absent from emitted events on both the snapshot/copy and streaming paths; **with** the fix all values arrive correctly (verified `b1=true/false`, `b8=0xAA/0xFF/0x55/0x0F`, `b64=0xAAAAAAAAAAAAAAAA`, `0x8000000000000001`, etc. against what SQL reports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)