### PR TITLE
.github: default setup-java to graalvm-community

### DIFF
--- a/.github/workflows/job.build.yml
+++ b/.github/workflows/job.build.yml
@@ -138,7 +138,7 @@ jobs:
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with:
           java-version: ${{ vars.JAVA_TOOLCHAIN_VERSION || '25' }}
-          distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'graalvm' }}
+          distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'graalvm-community' }}
       - name: "Setup: Elide"
         uses: elide-dev/setup-elide@d2f742321bf672300c0935839b6f5c6e562a965b # v4.1.0
       - name: "Setup: Gradle"

--- a/.github/workflows/job.build.yml
+++ b/.github/workflows/job.build.yml
@@ -135,7 +135,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: "Setup: JVM"
-        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: ${{ vars.JAVA_TOOLCHAIN_VERSION || '25' }}
           distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'graalvm-community' }}

--- a/.github/workflows/job.confluent-smoke.yml
+++ b/.github/workflows/job.confluent-smoke.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: "Setup: JVM"
         if: steps.gate.outputs.run == 'true'
-        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: ${{ vars.JAVA_TOOLCHAIN_VERSION || '25' }}
           distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'graalvm-community' }}

--- a/.github/workflows/job.confluent-smoke.yml
+++ b/.github/workflows/job.confluent-smoke.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with:
           java-version: ${{ vars.JAVA_TOOLCHAIN_VERSION || '25' }}
-          distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'graalvm' }}
+          distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'graalvm-community' }}
 
       - name: "Setup: Gradle"
         if: steps.gate.outputs.run == 'true'

--- a/.github/workflows/job.release.yml
+++ b/.github/workflows/job.release.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup: JVM"
-        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: ${{ vars.JAVA_TOOLCHAIN_VERSION || '25' }}
           distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'graalvm-community' }}

--- a/.github/workflows/job.release.yml
+++ b/.github/workflows/job.release.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with:
           java-version: ${{ vars.JAVA_TOOLCHAIN_VERSION || '25' }}
-          distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'graalvm' }}
+          distribution: ${{ vars.JAVA_TOOLCHAIN_VENDOR || 'graalvm-community' }}
 
       - name: "Setup: Gradle"
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v4


### PR DESCRIPTION
**Problem:**

https://github.com/planetscale/debezium-connector-planetscale/actions/runs/30558822467/job/90926288315

`PlanetscaleConventionsPlugin` pins toolchain vendor `GraalVM Community` + `nativeImageCapable`. CI `setup-java` defaulted to Oracle `graalvm`, which does not match, so Gradle auto-provisions via foojay. Foojay's current CE 25 redirect is the GitHub releases index page, not a tarball (`Cannot expand TAR .../releases-GraalVM#20Community-25`). Build fails before tests run.

**Solution:**

Default `distribution` to `graalvm-community` in `job.build.yml`, `job.release.yml`, and `job.confluent-smoke.yml` so `JAVA_HOME` matches the toolchain filter.

---

_Security Impact:_

None.

---

_Testing:_

* [ ] CI Build and Test on this PR

Made with [Cursor](https://cursor.com)